### PR TITLE
Fix 500 and 404 errors in chore application

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,7 +102,7 @@ def all_chores():
 
     # Custom sort key for status
     status_map = {"Overdue": 1, "Due Soon": 2, "Completed Recently": 3}
-    chores.sort(key=lambda c: (status_map.get(c.status, 4), not c.is_priority, c.next_due, -c.frequency))
+    chores.sort(key=lambda c: (status_map.get(c.status, 4), not c.is_priority, c.next_due or date.max, -c.frequency))
 
     return render_template('index.html', chores=chores, title="All Chores")
 
@@ -120,7 +120,7 @@ def search():
         chores = query.all()
         # Sort results just like in all_chores
         status_map = {"Overdue": 1, "Due Soon": 2, "Completed Recently": 3}
-        chores.sort(key=lambda c: (status_map.get(c.status, 4), not c.is_priority, c.next_due, -c.frequency))
+        chores.sort(key=lambda c: (status_map.get(c.status, 4), not c.is_priority, c.next_due or date.max, -c.frequency))
 
     return render_template('search.html', chores=chores, title="Search Chores")
 
@@ -164,7 +164,7 @@ def get_chore(chore_id):
         'assignee': chore.assignee.name,
         'category': chore.category,
         'frequency': chore.frequency,
-        'last_completed': chore.last_completed.isoformat(),
+        'last_completed': chore.last_completed.isoformat() if chore.last_completed else None,
         'is_priority': chore.is_priority,
         'notes': chore.notes,
         'next_due': chore.next_due.isoformat() if chore.next_due else None,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,7 +8,7 @@ function toggleModal(event) {
 }
 
 async function openChoreDetail(event) {
-    const choreRow = event.currentTarget;
+    const choreRow = event.currentTarget.closest('.chore-row');
     const choreId = choreRow.dataset.choreId;
 
     try {


### PR DESCRIPTION
This commit addresses several bugs causing 500 and 404 errors:

1.  **Fix 500 error on pages with sorting:** The chore sorting logic in the `all_chores` and `search` routes did not handle `None` for `next_due` dates, causing a `TypeError`. The sorting key has been updated to handle `None` values gracefully.

2.  **Fix 500 error in chore detail API:** The `/api/chores/<id>` endpoint would raise an `AttributeError` if a chore's `last_completed` date was `None`. Added a check to handle this case.

3.  **Fix 404 error in chore detail view:** The JavaScript function to open the chore detail modal was looking for the `data-chore-id` attribute on the wrong element, causing the `fetch` request to go to `/api/chores/undefined`. The code has been corrected to find the right element using `closest('.chore-row')`.