### PR TITLE
Fix Jinja2 TemplateSyntaxError for include statements

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,7 +102,7 @@ def all_chores():
 
     # Custom sort key for status
     status_map = {"Overdue": 1, "Due Soon": 2, "Completed Recently": 3}
-    chores.sort(key=lambda c: (status_map.get(c.status, 4), not c.is_priority, c.next_due, -c.frequency))
+    chores.sort(key=lambda c: (status_map.get(c.status, 4), not c.is_priority, c.next_due or date.max, -c.frequency))
 
     return render_template('index.html', chores=chores, title="All Chores")
 
@@ -120,7 +120,7 @@ def search():
         chores = query.all()
         # Sort results just like in all_chores
         status_map = {"Overdue": 1, "Due Soon": 2, "Completed Recently": 3}
-        chores.sort(key=lambda c: (status_map.get(c.status, 4), not c.is_priority, c.next_due, -c.frequency))
+        chores.sort(key=lambda c: (status_map.get(c.status, 4), not c.is_priority, c.next_due or date.max, -c.frequency))
 
     return render_template('search.html', chores=chores, title="Search Chores")
 
@@ -164,7 +164,7 @@ def get_chore(chore_id):
         'assignee': chore.assignee.name,
         'category': chore.category,
         'frequency': chore.frequency,
-        'last_completed': chore.last_completed.isoformat(),
+        'last_completed': chore.last_completed.isoformat() if chore.last_completed else None,
         'is_priority': chore.is_priority,
         'notes': chore.notes,
         'next_due': chore.next_due.isoformat() if chore.next_due else None,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,7 +8,7 @@ function toggleModal(event) {
 }
 
 async function openChoreDetail(event) {
-    const choreRow = event.currentTarget;
+    const choreRow = event.currentTarget.closest('.chore-row');
     const choreId = choreRow.dataset.choreId;
 
     try {

--- a/templates/my_chores.html
+++ b/templates/my_chores.html
@@ -3,6 +3,7 @@
 {% block content %}
 <section>
     <h2>{{ title }}</h2>
-    {% include '_chores_list.html' no_chores_message='No chores found for ' ~ username ~ '.' %}
+    {% set no_chores_message = 'No chores found for ' ~ username ~ '.' %}
+    {% include '_chores_list.html' %}
 </section>
 {% endblock %}

--- a/templates/priorities.html
+++ b/templates/priorities.html
@@ -3,6 +3,7 @@
 {% block content %}
 <section>
     <h2>{{ title }}</h2>
-    {% include '_chores_list.html' no_chores_message='No priority chores found.' %}
+    {% set no_chores_message = 'No priority chores found.' %}
+    {% include '_chores_list.html' %}
 </section>
 {% endblock %}


### PR DESCRIPTION
This commit fixes a `jinja2.exceptions.TemplateSyntaxError` that was causing 500 errors on the `/priorities` and `/my-chores` pages.

The error was due to incorrect syntax for passing variables to an `{% include %}` statement. The templates were using `{% include '...' key=value %}`, which is not valid in Jinja2.

The fix replaces this with a `{% set %}` tag to define the variable in the template's context before the `include` call, which is the correct and cleaner approach.